### PR TITLE
[FIX] Handle first release when no tags exist (#5)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,17 +22,12 @@ jobs:
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous tags found, starting from v0.1.0"
-            LAST_TAG="v0.0.0"
-            IS_FIRST_RELEASE=true
-          else
-            IS_FIRST_RELEASE=false
-          fi
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Last tag: $LAST_TAG"
+
           FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
           echo "Commit subject: $FIRST_LINE"
+
           if [[ "$FIRST_LINE" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="v${BASH_REMATCH[1]}"
             echo "Version from commit: $VERSION"
@@ -44,9 +39,9 @@ jobs:
             VERSION="v${MAJOR}.${MINOR}.${PATCH}"
             echo "Auto-incremented version: $VERSION"
           fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
-          echo "is_first_release=$IS_FIRST_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag exists
         id: check
@@ -66,7 +61,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          CHANGELOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          # Check if LAST_TAG is a real tag or just the default v0.0.0
+          if git rev-parse "${LAST_TAG}" >/dev/null 2>&1; then
+            CHANGELOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          else
+            CHANGELOG=$(git log HEAD --pretty=format:"- %s (%h)" --no-merges)
+          fi
 
           git tag -a "$VERSION" -m "Release ${VERSION}
 
@@ -83,34 +83,41 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           LAST_TAG: ${{ steps.version.outputs.last_tag }}
         run: |
+          # Check if LAST_TAG is a real tag
+          if git rev-parse "${LAST_TAG}" >/dev/null 2>&1; then
+            RANGE="${LAST_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
           {
             echo "# Release ${VERSION}"
             echo ""
             echo "## Changes since ${LAST_TAG}"
             echo ""
 
-            FEATS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges --grep="^feat")
+            FEATS=$(git log "${RANGE}" --pretty=format:"- %s (%h)" --no-merges --grep="^feat")
             if [ -n "$FEATS" ]; then
               echo "### ✨ Features"
               echo "$FEATS"
               echo ""
             fi
 
-            FIXES=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges --grep="^fix")
+            FIXES=$(git log "${RANGE}" --pretty=format:"- %s (%h)" --no-merges --grep="^fix")
             if [ -n "$FIXES" ]; then
               echo "### 🐛 Bug Fixes"
               echo "$FIXES"
               echo ""
             fi
 
-            DOCS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges --grep="^docs")
+            DOCS=$(git log "${RANGE}" --pretty=format:"- %s (%h)" --no-merges --grep="^docs")
             if [ -n "$DOCS" ]; then
               echo "### 📚 Documentation"
               echo "$DOCS"
               echo ""
             fi
 
-            REFACTORS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges --grep="^refactor")
+            REFACTORS=$(git log "${RANGE}" --pretty=format:"- %s (%h)" --no-merges --grep="^refactor")
             if [ -n "$REFACTORS" ]; then
               echo "### ♻️ Refactoring"
               echo "$REFACTORS"
@@ -120,7 +127,7 @@ jobs:
             echo "---"
             echo ""
             echo "### All Commits"
-            git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges
+            git log "${RANGE}" --pretty=format:"- %s (%h)" --no-merges
           } > RELEASE_NOTES.md
 
           cat RELEASE_NOTES.md


### PR DESCRIPTION
## Description

Fix auto-release workflow to handle the first release case when no tags exist in the repository.

## Type of Change

- [x] Bug fix

## Changes Made

- Add conditional check for LAST_TAG existence before using in git log ranges
- Use 'git log HEAD' when LAST_TAG is not a real tag (first release)
- Apply same pattern as agentgram-mcp for consistency
- Fixes changelog and release notes generation for initial releases

## Related Issues

Closes #5

## Testing

- [x] Manual testing performed
- [x] Follows agentgram-mcp pattern

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings