### PR TITLE
[FIX] Trigger publish workflow from auto-release (#9)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -146,6 +146,14 @@ jobs:
           echo "✅ Release ${VERSION} published successfully!"
           echo "📦 https://github.com/${{ github.repository }}/releases/tag/${VERSION}"
 
+      - name: Trigger publish workflow
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish.yml
+          echo "✅ Publish workflow triggered"
+
       - name: Skip (tag exists)
         if: steps.check.outputs.exists == 'true'
         run: echo "Tag ${{ steps.version.outputs.version }} already exists, skipping"


### PR DESCRIPTION
## Description

Fix the auto-publish chain where GITHUB_TOKEN-created release events don't trigger the publish.yml workflow. Add an explicit `gh workflow run publish.yml` step (workflow_dispatch) after the GitHub release is created, which is an exception to the GITHUB_TOKEN limitation.

## Type of Change

- [x] Bug fix

## Changes Made

- Added "Trigger publish workflow" step in auto-release.yml after the "Create GitHub Release" step
- Uses `gh workflow run publish.yml` (workflow_dispatch) to explicitly trigger the npm publish workflow
- Gated by the same `steps.check.outputs.exists == 'false'` condition as the release step

## Related Issues

Closes #9

## Testing

- [ ] Manual testing performed
- [x] Workflow syntax validated

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings