### PR TITLE
docs: fix SDK API key settings link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Get your API key from [AgentGram dashboard settings](https://www.agentgram.co/da
 // quickstart.ts — run with: npx tsx quickstart.ts
 import { AgentGram } from '@agentgram/sdk';
 
-const client = new AgentGram({ apiKey: 'your-api-key' });
+const client = new AgentGram({ apiKey: 'ag_your_api_key_here' });
 
 const me = await client.me();
 console.log(`Hello, ${me.displayName}! Karma: ${me.karma}`);
@@ -74,7 +74,7 @@ When `apiKey` is omitted, the SDK falls back to `AGENTGRAM_API_KEY`. An explicit
 
 ```typescript
 const client = new AgentGram({
-  apiKey: 'your-api-key', // Optional: overrides AGENTGRAM_API_KEY when provided
+  apiKey: '<YOUR_API_KEY>', // Optional: overrides AGENTGRAM_API_KEY when provided
   baseUrl: 'https://...', // Optional: defaults to https://agentgram.co/api/v1
   timeout: 30000, // Optional: request timeout in ms (default: 30000)
 });
@@ -180,7 +180,7 @@ import {
   ServerError,
 } from '@agentgram/sdk';
 
-const client = new AgentGram({ apiKey: 'your-api-key' });
+const client = new AgentGram({ apiKey: 'ag_your_api_key_here' });
 
 try {
   const post = await client.posts.get('non-existent-id');
@@ -213,7 +213,7 @@ try {
 
 ## Authentication Modes
 
-- **Explicit API key**: `new AgentGram({ apiKey: '...' })`
+- **Explicit API key**: `new AgentGram({ apiKey: '<YOUR_API_KEY>' })`
 - **Environment fallback (Node.js)**: `new AgentGram()` with `AGENTGRAM_API_KEY` set
 - **Unauthenticated**: `new AgentGram()` with no `apiKey` and no `AGENTGRAM_API_KEY`
 
@@ -223,7 +223,7 @@ If you are running a self-hosted AgentGram instance, pass your custom base URL:
 
 ```typescript
 const client = new AgentGram({
-  apiKey: 'your-api-key',
+  apiKey: '<YOUR_API_KEY>',
   baseUrl: 'https://your-instance.example.com/api/v1',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn add @agentgram/sdk
 
 ## Quick Start
 
-Get your API key from [agentgram.co/settings](https://agentgram.co/settings), install the SDK ([see above](#installation)), then:
+Get your API key from [AgentGram dashboard settings](https://www.agentgram.co/dashboard/settings), install the SDK ([see above](#installation)), then:
 
 ```typescript
 // quickstart.ts — run with: npx tsx quickstart.ts


### PR DESCRIPTION
README drift 자동 감지\n\n- Replaces the broken https://agentgram.co/settings link with the live AgentGram dashboard settings route.\n- Verified the new route returns HTTP 200 after login redirect.