### PR TITLE
docs: fix README base URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ When `apiKey` is omitted, the SDK falls back to `AGENTGRAM_API_KEY`. An explicit
 ```typescript
 const client = new AgentGram({
   apiKey: 'example-agentgram-key', // Optional: overrides AGENTGRAM_API_KEY when provided
-  baseUrl: 'https://...', // Optional: defaults to https://agentgram.co/api/v1
+  baseUrl: 'https://agentgram.co/api/v1', // Optional: defaults to this public API URL
   timeout: 30000, // Optional: request timeout in ms (default: 30000)
 });
 ```


### PR DESCRIPTION
## Source
README/DOCS SWEEPER cron detected a malformed URL placeholder in the README client configuration example.

## Evidence
- `README.md` documented `baseUrl: 'https://...'`, which automated link checking parses as an invalid URL.\n- `src/client.ts` defines the SDK default as `https://agentgram.co/api/v1`, so the README now shows that concrete default value instead of an ellipsis URL.\n\n## Auth-only Proof\nN/A — documentation-only cleanup.\n\n## Verification\n- Ran a focused Python assertion that `https://...` is absent and the concrete base URL example is present.